### PR TITLE
Add Skirt Around Keyboard

### DIFF
--- a/keebgen/geometry_base.py
+++ b/keebgen/geometry_base.py
@@ -27,7 +27,6 @@ class Part(metaclass=BetterABCMeta):
         self._solid = sl.rotate([x, y, z])(self._solid)
         self._anchors.rotate(x,y,z)
 
-
     def anchors(self):
         return self._anchors
 

--- a/keebgen/geometry_utils.py
+++ b/keebgen/geometry_utils.py
@@ -1,5 +1,7 @@
 from numpy import pi
 from scipy.spatial.transform import Rotation
+from numpy.linalg import norm
+import numpy as np
 
 def deg2rad(degrees: float) -> float:
     return degrees * pi / 180
@@ -45,3 +47,10 @@ def mean_point(points):
     mean_point[1] = mean_point[1] / len(points)
     mean_point[2] = mean_point[2] / len(points)
     return mean_point
+
+# return vector of length one pointing from 1->2
+def unit_vector(point1, point2):
+    point1 = np.array(point1)
+    point2 = np.array(point2)
+    dir_vec = point2 - point1
+    return dir_vec / norm(dir_vec)

--- a/keebgen/key_assy.py
+++ b/keebgen/key_assy.py
@@ -35,7 +35,6 @@ class KeyAssy(Assembly):
                                                          self.anchors_by_part('socket')['top'])
 
 
-
 # FaceAlignedKeys will have the faces forming a smooth curve on the keybaord regardless of switch and keycap type
 class FaceAlignedKey(KeyAssy):
     def __init__(self, config, socket_config, r, u=1):
@@ -69,6 +68,7 @@ class FaceAlignedKey(KeyAssy):
         # translate so face centered on Z axis, and planar with xy plane
         center_anchor = utils.mean_point(self._anchors['top'].coords)
         self.translate(-center_anchor[0], -center_anchor[1], -center_anchor[2])
+
 
 # simplest case, the switches are aligned based on the socket.
 # should be used for plate mount boards

--- a/keebgen/key_column.py
+++ b/keebgen/key_column.py
@@ -10,6 +10,11 @@ class KeyColumn(Assembly):
     @abstractmethod
     def __init__(self):
         super().__init__()
+        # must define self._front_socket_name and self._back_socket_name in constructor
+
+    def get_key_names(self):
+        return self._key_names
+
 
 class ConcaveOrtholinearColumn(KeyColumn):
     def __init__(self, config, key_config, socket_config):
@@ -24,6 +29,7 @@ class ConcaveOrtholinearColumn(KeyColumn):
         home_angle = config.getfloat('home_tiltback_angle')
 
         prev_anchors = None
+        self._key_names = []
         for i in range(num_keys):
             r = 4-i + (home_index-1)
             rotation_index = i - home_index
@@ -34,7 +40,7 @@ class ConcaveOrtholinearColumn(KeyColumn):
 
             # for alignment across rows, name keys by index from the home row. negative is below home
             key_name = rotation_index
-
+            self._key_names.append(key_name)
 
             # add a key_assy to the parts
             self._parts.add(FaceAlignedKey(key_config, socket_config, r), key_name)

--- a/keebgen/keyboard.py
+++ b/keebgen/keyboard.py
@@ -215,7 +215,8 @@ class DactylManuform(Keyboard):
         conf = configparser.ConfigParser()
         conf['skirt'] = {}
         conf['skirt']['wall_thickness'] = '2.0'
-        conf['skirt']['flare_size'] = '7.0'
+        conf['skirt']['flare_len'] = '4.0'
+        conf['skirt']['flare_angle'] = '30.0'
 
         # TODO translation should happen based on the config, or based on the minimum Z height of all parts
         # to make sure all parts of the keyboard stay above the xy plane

--- a/keebgen/skirt.py
+++ b/keebgen/skirt.py
@@ -20,7 +20,6 @@ class FlaredSkirt(Assembly):
         for edge_pair in edge_pairs:
             # make sure pair is a pair
             assert(len(edge_pair) == 2)
-
             segments.append(self._make_skirt_segment(edge_pair[0], edge_pair[1]))
 
         self._parts = PartCollection()

--- a/keebgen/skirt.py
+++ b/keebgen/skirt.py
@@ -1,0 +1,116 @@
+from math import sqrt
+from .better_abc import abstractmethod
+from .geometry_base import Assembly, LabeledPoint, AnchorCollection, PartCollection, CuboidAnchorCollection
+from .connector import Connector
+from .geometry_utils import unit_vector
+import numpy as np
+import copy
+
+class FlaredSkirt(Assembly):
+    # edge pairs in the format of (top_edge, outer_edge),
+    # where each edge is made of two anchor points
+    # edges will be connected consecutively and last will connect to first
+    def __init__(self, edge_pairs, config):
+        super().__init__()
+
+        self._thickness = config.getfloat('wall_thickness')
+        self._flare_size = config.getfloat('flare_size')
+
+        segments = []
+        for edge_pair in edge_pairs:
+            # make sure pair is a pair
+            assert(len(edge_pair) == 2)
+
+            segments.append(self._make_skirt_segment(edge_pair[0], edge_pair[1]))
+
+        self._parts = PartCollection()
+        prev_segment = segments[-1]
+
+        for segment in segments:
+            self._parts.add(Connector(segment['top'] + segment['middle'] + prev_segment['top'] + prev_segment['middle']))
+            self._parts.add(Connector(segment['middle'] + segment['bottom'] + prev_segment['middle'] + prev_segment['bottom']))
+            self._anchors = CuboidAnchorCollection.create()
+            prev_segment = segment
+
+    def _same_anchor(self, anchor1, anchor2):
+        for coord1, coord2 in zip(anchor1.coords, anchor2.coords):
+            if coord1 != coord2:
+                return False
+        return True
+
+    # two edges actually made up of three points
+    def _make_skirt_segment(self, top_edge, outer_edge):
+    # known limitation: if the wall thickness is larger than the flare_size,
+    # then the wall will encroach on the provided front edges
+        '''
+         top_edge
+        --------|
+                | outer_edge
+        --------|
+
+
+        --------|\
+                | \
+        --------|  \ sloping wall
+                 \  \
+                  \  \
+                  |  |
+                  |  | vertical wall to xy plane
+                  |__|
+        '''
+        # make sure there are only 2 points in each edge
+        assert len(top_edge) == 2
+        assert len(outer_edge) == 2
+
+        # identify each corner
+        shared_point = None
+        bottom_point = None
+        back_point = None
+        for top_point in top_edge:
+            for outer_point in outer_edge:
+                if self._same_anchor(top_point, outer_point):
+                    point_check = top_point
+                    shared_point = np.array(top_point.coords)
+                    break
+        for top_point in top_edge:
+            if not self._same_anchor(top_point, point_check):
+                back_point = np.array(top_point.coords)
+                break
+        for outer_point in outer_edge:
+            if not self._same_anchor(outer_point, point_check):
+                bottom_point = np.array(outer_point.coords)
+                break
+
+        # make sure all assigned. Will fail if two identical edges provided as input
+        assert len(shared_point) == 3
+        assert len(bottom_point) == 3
+        assert len(back_point) == 3
+
+        # unit vector pointing out, in line with the top edge
+        top_dir = unit_vector(back_point, shared_point)
+        # unit vector pointing down, in line with the outer edge
+        front_dir = unit_vector(shared_point, bottom_point)
+
+        wall_hyp = sqrt(2) * self._thickness
+
+        ret_points = [LabeledPoint(shared_point, ('outside', 'top')),
+                LabeledPoint(front_dir*wall_hyp+shared_point, ('inside', 'top'))]
+        mid_outer_corner = shared_point + top_dir*self._flare_size + front_dir*self._flare_size
+        ret_points.append(LabeledPoint(mid_outer_corner, ('outside', 'middle')))
+
+        bottom_outer_corner = copy.deepcopy(mid_outer_corner)
+        bottom_outer_corner[2] = 0.0
+        ret_points.append(LabeledPoint(bottom_outer_corner, ('bottom', 'outer')))
+
+        no_z_top_dir = copy.deepcopy(top_dir)
+        no_z_top_dir[2] = 0.0
+        no_z_top_dir = unit_vector((0,0,0), no_z_top_dir)
+
+        mid_inner_corner = mid_outer_corner - no_z_top_dir * self._thickness
+        bottom_inner_corner = bottom_outer_corner - no_z_top_dir * self._thickness
+
+        ret_points.append(LabeledPoint(mid_inner_corner, ('middle', 'inner')))
+        ret_points.append(LabeledPoint(bottom_inner_corner, ('bottom', 'inner')))
+
+        # return a plane of segments in order of top, middle, bottom
+        return AnchorCollection(ret_points)

--- a/keebgen/switch_socket.py
+++ b/keebgen/switch_socket.py
@@ -59,5 +59,3 @@ class CherryMXSocket(Part):
         self._solid = socket
         self._anchors = CuboidAnchorCollection.create(dims=(width, length, thickness),
                                                       offset=(0, 0, -thickness/2))
-
-

--- a/skirt_test.py
+++ b/skirt_test.py
@@ -23,7 +23,8 @@ cube.rotate(30,0,0)
 conf = configparser.ConfigParser()
 conf['skirt'] = {}
 conf['skirt']['wall_thickness'] = '2.0'
-conf['skirt']['flare_size'] = '5.0'
+conf['skirt']['flare_len'] = '4.0'
+conf['skirt']['flare_angle'] = '50.0'
 
 skirt_edges = (
         (cube.anchors()['top','left'], cube.anchors()['front','left']),

--- a/skirt_test.py
+++ b/skirt_test.py
@@ -1,0 +1,44 @@
+from keebgen.connector import Connector
+from keebgen.geometry_base import AnchorCollection, LabeledPoint
+from keebgen.skirt import FlaredSkirt
+import configparser
+import solid as sl
+
+
+cube_input_corners = [
+            LabeledPoint((0, 0, 0), ('bottom', 'left', 'back')),
+            LabeledPoint((10, 0, 0), ('bottom', 'right', 'back')),
+            LabeledPoint((10, 10, 0), ('bottom', 'right', 'front')),
+            LabeledPoint((0, 10, 0), ('bottom', 'left', 'front')),
+            LabeledPoint((0, 0, 3), ('top', 'left', 'back')),
+            LabeledPoint((10, 0, 3), ('top', 'right', 'back')),
+            LabeledPoint((10, 10, 3), ('top', 'right', 'front')),
+            LabeledPoint((0, 10, 3), ('top', 'left', 'front'))
+            ]
+
+cube = Connector(AnchorCollection(cube_input_corners))
+cube.translate(0,0,25)
+cube.rotate(30,0,0)
+
+conf = configparser.ConfigParser()
+conf['skirt'] = {}
+conf['skirt']['wall_thickness'] = '2.0'
+conf['skirt']['flare_size'] = '5.0'
+
+skirt_edges = (
+        (cube.anchors()['top','left'], cube.anchors()['front','left']),
+        (cube.anchors()['top','right'], cube.anchors()['front','right']),
+        (cube.anchors()['top','front'], cube.anchors()['front','right']),
+        (cube.anchors()['top','back'], cube.anchors()['back','right']),
+        (cube.anchors()['top','right'], cube.anchors()['back','right']),
+        (cube.anchors()['top','left'], cube.anchors()['back','left']),
+        (cube.anchors()['top','back'], cube.anchors()['back','left']),
+        (cube.anchors()['top','front'], cube.anchors()['front','left']))
+
+skirt = FlaredSkirt(skirt_edges, conf['skirt'])
+
+solids = cube.solid()
+solids += skirt.solid()
+
+sl.scad_render_to_file(solids, 'skirt_test.scad')
+


### PR DESCRIPTION
This PR will have a new skirt class used to generate a skirt around a keyboard. Usually the keyboard will just be an array of key sockets laid out in free space

The skirt makes an esternal chamfer around the face to make room for soldering the switch inside of the case, and then projects the wall down to the x,y plane