### PR TITLE
Skirt to Use Convex Hull Footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ their own custom keyboards. This project was inspired by the Dactyl project,
 but is intended to be a genaric library of building blocks that can be used to
 quickly and easily design any type of keyboard.
 
-KeebGen provides users with common keybaord primatives that allow a user to
+KeebGen provides users with common keyboard primatives that allow a user to
 model an entire keyboard without having to worry about the minutia of a design.
 A Cherry MX switch is a standard part, so users should not have to re-draw a
 socket for it every time they want to design a new keyboard. Instead, they can
@@ -62,6 +62,10 @@ This is also possible in the OpenSCAD viewer window. Render the file with F6, th
 When customizing a keyboard, it can be helpful to have the OpenSCAD model open
 to see updates immediately automatically re-run python script on save. have
 OpenSCAD open
+
+to automatically run script whenever directory changes:
+`while true; do inotifywait -e modify <path_to_directory> && python3 <script to run>; done`
+`while true; do inotifywait -e modify keebgen && python3 examples.py; done`
 
 talk about printing smallest building block as you go. If you don't know
 printer parameters you need for a good socket, start by printing a socket only

--- a/keebgen/connector.py
+++ b/keebgen/connector.py
@@ -38,6 +38,6 @@ class Connector(Part):
         # using hull around tiny spheres is a hack, but whatever. saves a ton of code
         spheres = _make_spheres(self._anchors)
         # make sure we didn't end up with zero points
-        # we may want to adjust this functionality later and just return solid.part() for empty connectors
+        # TODO we may want to adjust this functionality later and just return solid.part() for empty connectors
         assert len(spheres) > 0
         self._solid = sl.hull()(*spheres)

--- a/keebgen/geometry_utils.py
+++ b/keebgen/geometry_utils.py
@@ -4,10 +4,10 @@ from numpy.linalg import norm
 import numpy as np
 
 def deg2rad(degrees: float) -> float:
-    return degrees * pi / 180
+    return np.deg2rad(degrees)
 
 def rad2deg(rad: float) -> float:
-    return rad * 180 / pi
+    return np.rad2deg(rad)
 
 # eulers are xyz euler angle in degrees
 # can rotate single point or N points
@@ -54,3 +54,27 @@ def unit_vector(point1, point2):
     point2 = np.array(point2)
     dir_vec = point2 - point1
     return dir_vec / norm(dir_vec)
+
+# return the angle from one vector to the other. ccw is + rotation
+# returns (-pi, pi]
+def vector_angle_2D(vec1, vec2, degrees=True):
+    assert len(vec1) == 2
+    assert len(vec2) == 2
+
+    # get angle between each and the horizontal, returns (0, 2pi]
+    def horizon_angle(vec):
+        # horizon is (1,0)
+        mag = np.arctan2(vec[1], vec[0])
+        if mag < 0:
+            mag += (2*pi)
+        return mag
+
+    angle = horizon_angle(vec2) - horizon_angle(vec1)
+    while angle > pi:
+        angle -= (2*pi)
+    while angle <= -pi:
+        angle += (2*pi)
+
+    if degrees:
+        return rad2deg(angle)
+    return angle

--- a/skirt_test.py
+++ b/skirt_test.py
@@ -16,9 +16,15 @@ cube_input_corners = [
             LabeledPoint((0, 10, 3), ('top', 'left', 'front'))
             ]
 
-cube = Connector(AnchorCollection(cube_input_corners))
-cube.translate(0,0,25)
-cube.rotate(30,0,0)
+cube0 = Connector(AnchorCollection(cube_input_corners))
+cube0.translate(0,0,25)
+cube0.rotate(30,0,0)
+
+cube1 = Connector(AnchorCollection(cube_input_corners))
+cube1.translate(5,5,25)
+cube1.rotate(15,0,0)
+
+cube_connection = Connector(AnchorCollection(cube1.anchors()['back'] + cube0.anchors()['front']))
 
 conf = configparser.ConfigParser()
 conf['skirt'] = {}
@@ -27,18 +33,23 @@ conf['skirt']['flare_len'] = '4.0'
 conf['skirt']['flare_angle'] = '50.0'
 
 skirt_edges = (
-        (cube.anchors()['top','left'], cube.anchors()['front','left']),
-        (cube.anchors()['top','right'], cube.anchors()['front','right']),
-        (cube.anchors()['top','front'], cube.anchors()['front','right']),
-        (cube.anchors()['top','back'], cube.anchors()['back','right']),
-        (cube.anchors()['top','right'], cube.anchors()['back','right']),
-        (cube.anchors()['top','left'], cube.anchors()['back','left']),
-        (cube.anchors()['top','back'], cube.anchors()['back','left']),
-        (cube.anchors()['top','front'], cube.anchors()['front','left']))
+        (cube1.anchors()['top','left'], cube1.anchors()['front','left']),
+        (cube1.anchors()['top','right'], cube1.anchors()['front','right']),
+        (cube1.anchors()['top','front'], cube1.anchors()['front','right']),
+        (cube1.anchors()['top','back'], cube1.anchors()['back','right']),
+        (cube0.anchors()['top','front'], cube0.anchors()['front','right']),
+        (cube0.anchors()['top','back'], cube0.anchors()['back','right']),
+
+        (cube0.anchors()['top','right'], cube0.anchors()['back','right']),
+        (cube0.anchors()['top','left'],  cube0.anchors()['back','left']),
+        (cube0.anchors()['top','back'],  cube0.anchors()['back','left']),
+        (cube0.anchors()['top','front'], cube0.anchors()['front','left']),
+        (cube1.anchors()['top','back'],  cube1.anchors()['back','left']),
+        (cube1.anchors()['top','front'], cube1.anchors()['front','left']))
 
 skirt = FlaredSkirt(skirt_edges, conf['skirt'])
 
-solids = cube.solid()
+solids = cube0.solid() + cube1.solid() + cube_connection.solid()
 solids += skirt.solid()
 
 sl.scad_render_to_file(solids, 'skirt_test.scad')


### PR DESCRIPTION
This PR converts the footprint of the skirt to become the convex hull of the overall perimeter. This improves stability and makes it more likely that the skirt is 3D printable. It also make sit easier to create a bottom cover for the skirt because it will be a convex hull of all bottom skirt points


![Peek 2021-05-31 10-54](https://user-images.githubusercontent.com/3112909/120211171-a17b5300-c1fe-11eb-934d-9646a72d8dc6.gif)

Compare to skirt before adding hull feature. Notice the thin walls between key columns, and very jagged external profile
![Peek 2021-05-31 10-56](https://user-images.githubusercontent.com/3112909/120211445-ef905680-c1fe-11eb-8d21-948d90a05bcf.gif)
